### PR TITLE
Fix asset paths on windows

### DIFF
--- a/src/iostore_writer.rs
+++ b/src/iostore_writer.rs
@@ -80,7 +80,9 @@ impl IoStoreWriter {
                     index.mount_point
                 )
             })?;
-            index.add_file(relative_path, self.toc.chunks.len() as u32);
+            // Convert any backslashes to forward slashes.
+            let relative_path = relative_path.replace('\\', "/");
+            index.add_file(&relative_path, self.toc.chunks.len() as u32);
         }
 
         let mut offset = self.cas_stream.stream_position()?;


### PR DESCRIPTION
Fixes asset paths in utoc when converting from legacy to Zen on windows