### PR TITLE
Fixes mount point and relative paths in UTOC when gathering from loose assets

### DIFF
--- a/src/iostore_writer.rs
+++ b/src/iostore_writer.rs
@@ -80,7 +80,9 @@ impl IoStoreWriter {
                     index.mount_point
                 )
             })?;
-            index.add_file(relative_path, self.toc.chunks.len() as u32);
+            // Convert any backslashes to forward slashes.
+            let relative_path = relative_path.replace('\\', "/");
+            index.add_file(&relative_path, self.toc.chunks.len() as u32);
         }
 
         let mut offset = self.cas_stream.stream_position()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -978,11 +978,18 @@ fn action_to_zen(args: ActionToZen, _config: Arc<Config>) -> Result<()> {
         Box::new(PakFileReader::new(args.input)?)
     };
 
+    let files = input.list_files()?;
+    let common_prefix = compute_common_prefix(&files);
+    let mount_point = if common_prefix.is_empty() {
+        "../../../".to_string()
+    } else {
+        format!("../../../{}", common_prefix)
+    };
     let mut writer = IoStoreWriter::new(
         &args.output,
         args.version.toc_version(),
         Some(args.version.container_header_version()),
-        mount_point.to_string(),
+        mount_point.clone(),
     )?;
 
     let log = Log::new(args.verbose, args.debug);

--- a/src/main.rs
+++ b/src/main.rs
@@ -809,6 +809,35 @@ fn progress_style() -> indicatif::ProgressStyle {
     .progress_chars("##-")
 }
 
+fn compute_common_prefix(paths: &[String]) -> String {
+    if paths.is_empty() {
+        return "".to_string();
+    }
+    let path_components: Vec<Vec<&str>> = paths
+        .iter()
+        .map(|p| {
+            let trimmed = p.strip_prefix("../../../").unwrap_or(p);
+            trimmed.split('\\').filter(|s| !s.is_empty()).collect()
+        })
+        .collect();
+
+    let mut common = path_components[0].clone();
+    for comps in path_components.iter().skip(1) {
+        let min_len = common.len().min(comps.len());
+        let mut new_common = Vec::new();
+        for i in 0..min_len {
+            if common[i] == comps[i] {
+                new_common.push(common[i]);
+            } else {
+                break;
+            }
+        }
+        common = new_common;
+    }
+    common.join("/")
+}
+
+
 fn action_to_legacy_assets(
     args: &ActionToLegacy,
     file_writer: &dyn FileWriterTrait,


### PR DESCRIPTION
Unsure if this breaks anything else, but this is the extent of my rust ability.  Likely won't want to use any of the code other than maybe the compute_common_prefix function.