### PR TITLE
Add compression support to IoStoreWriter

### DIFF
--- a/retoc/src/iostore_writer.rs
+++ b/retoc/src/iostore_writer.rs
@@ -1,6 +1,7 @@
 use crate::{
     EIoChunkType, FPackageId, UEPath, UEPathBuf, align_usize,
     chunk_id::FIoChunkIdRaw,
+    compression::{CompressionMethod, compress},
     container_header::{EIoContainerHeaderVersion, FIoContainerHeader, StoreEntry},
 };
 use crate::{EIoStoreTocVersion, FIoChunkHash, FIoChunkId, FIoContainerId, FIoOffsetAndLength, FIoStoreTocCompressedBlockEntry, FIoStoreTocEntryMeta, FIoStoreTocEntryMetaFlags, Toc, ser::*};
@@ -19,10 +20,11 @@ pub struct IoStoreWriter {
     cas_stream: BufWriter<fs::File>,
     toc: Toc,
     container_header: Option<FIoContainerHeader>,
+    compression: Option<CompressionMethod>,
 }
 
 impl IoStoreWriter {
-    pub fn new<P: AsRef<Path>>(toc_path: P, toc_version: EIoStoreTocVersion, container_header_version: Option<EIoContainerHeaderVersion>, mount_point: UEPathBuf) -> Result<Self> {
+    pub fn new<P: AsRef<Path>>(toc_path: P, toc_version: EIoStoreTocVersion, container_header_version: Option<EIoContainerHeaderVersion>, mount_point: UEPathBuf, compression: Option<CompressionMethod>) -> Result<Self> {
         let toc_path = toc_path.as_ref().to_path_buf();
         let name = toc_path.file_stem().unwrap().to_string_lossy();
         let toc_stream = BufWriter::new(fs::File::create(&toc_path)?);
@@ -34,6 +36,10 @@ impl IoStoreWriter {
         toc.container_id = FIoContainerId::from_name(&name);
         toc.directory_index.mount_point = mount_point;
         toc.partition_size = u64::MAX;
+        if let Some(method) = compression {
+            toc.compression_methods.push(method);
+            toc.container_flags |= crate::EIoContainerFlags::Compressed
+        }
 
         let container_header = container_header_version.map(|v| FIoContainerHeader::new(v, toc.container_id));
 
@@ -43,40 +49,65 @@ impl IoStoreWriter {
             cas_stream,
             toc,
             container_header,
+            compression,
         })
     }
     pub fn write_chunk_raw(&mut self, chunk_id_raw: FIoChunkIdRaw, path: Option<&UEPath>, data: &[u8]) -> Result<()> {
         self.write_chunk(FIoChunkId::from_raw(chunk_id_raw, self.toc.version), path, data)
     }
+
     pub fn write_chunk(&mut self, chunk_id: FIoChunkId, path: Option<&UEPath>, data: &[u8]) -> Result<()> {
+        self.write_chunk_inner(chunk_id, path, data, self.compression)
+    }
+
+    pub fn write_chunk_uncompressed(&mut self, chunk_id: FIoChunkId, path: Option<&UEPath>, data: &[u8]) -> Result<()> {
+        self.write_chunk_inner(chunk_id, path, data, None)
+    }
+
+    fn write_chunk_inner(&mut self, chunk_id: FIoChunkId, path: Option<&UEPath>, data: &[u8], compression: Option<CompressionMethod>) -> Result<()> {
         if let Some(path) = path {
             let index = &mut self.toc.directory_index;
             let relative_path = path.strip_prefix(&index.mount_point).with_context(|| format!("mount point {} does not contain path {path}", index.mount_point))?;
             index.add_file(relative_path, self.toc.chunks.len() as u32);
         }
 
+        self.cas_stream.flush()?;
         let mut offset = self.cas_stream.stream_position()?;
-
         let start_block = self.toc.compression_blocks.len();
-
         let mut hasher = blake3::Hasher::new();
+
         for block in data.chunks(self.toc.compression_block_size as usize) {
-            self.cas_stream.write_all(block)?;
             hasher.update(block);
-            let compressed_size = block.len() as u32;
+
+            let (bytes_to_write, compression_method_index) = match compression {
+                Some(method) => {
+                    let mut compressed = Vec::new();
+                    compress(method, block, &mut compressed)?;
+                    if compressed.len() < block.len() {
+                        (compressed, 1u8)
+                    } else {
+                        (block.to_vec(), 0u8)
+                    }
+                }
+                None => (block.to_vec(), 0u8),
+            };
+
+            let compressed_size = bytes_to_write.len() as u32;
             let uncompressed_size = block.len() as u32;
-            let compression_method_index = 0; // "None"
-            self.toc.compression_blocks.push(FIoStoreTocCompressedBlockEntry::new(offset, compressed_size, uncompressed_size, compression_method_index));
-            offset += compressed_size as u64;
+
+            self.cas_stream.write_all(&bytes_to_write)?;
+
+            let written_size = bytes_to_write.len() as u32;
+            self.toc.compression_blocks.push(FIoStoreTocCompressedBlockEntry::new(offset,compressed_size,uncompressed_size,compression_method_index));
+            offset += written_size as u64;
         }
+
         let hash = hasher.finalize();
         let meta = FIoStoreTocEntryMeta {
             chunk_hash: FIoChunkHash::from_blake3(hash.as_bytes()),
             flags: FIoStoreTocEntryMetaFlags::empty(),
         };
-
-        let offset_and_length = FIoOffsetAndLength::new(start_block as u64 * self.toc.compression_block_size as u64, data.len() as u64);
-
+        let offset_and_length = FIoOffsetAndLength::new(start_block as u64 * self.toc.compression_block_size as u64,data.len() as u64,);
         self.toc.chunks.push(chunk_id.with_version(self.toc.version));
         self.toc.chunk_offset_lengths.push(offset_and_length);
         self.toc.chunk_metas.push(meta);
@@ -110,8 +141,8 @@ impl IoStoreWriter {
             // container header is always aligned for AES for some reason
             chunk_buffer.resize(align_usize(chunk_buffer.len(), 16), 0);
 
-            let chunk_id = FIoChunkId::create(container_header.container_id.0, 0, EIoChunkType::ContainerHeader);
-            self.write_chunk(chunk_id, None, &chunk_buffer)?;
+            let chunk_id = FIoChunkId::create(container_header.container_id.0,0,EIoChunkType::ContainerHeader);
+            self.write_chunk_uncompressed(chunk_id, None, &chunk_buffer)?;
         }
         self.toc_stream.ser(&self.toc)?;
         Ok(())
@@ -126,7 +157,7 @@ mod test {
     #[test]
     fn test_write_container() -> Result<()> {
         fs::create_dir("out").ok();
-        let mut writer = IoStoreWriter::new("out/new.utoc", EIoStoreTocVersion::PerfectHashWithOverflow, Some(EIoContainerHeaderVersion::OptionalSegmentPackages), "../../..".into())?;
+        let mut writer = IoStoreWriter::new("out/new.utoc", EIoStoreTocVersion::PerfectHashWithOverflow, Some(EIoContainerHeaderVersion::OptionalSegmentPackages), "../../..".into(),None)?;
 
         let data = fs::read("tests/UE5.3/ScriptObjects.bin")?;
         writer.write_chunk_raw(FIoChunkIdRaw { id: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5] }, Some(UEPath::new("../../../asdf/asdf/dasf/script_objects.bin")), &data)?;

--- a/retoc_cli/src/main.rs
+++ b/retoc_cli/src/main.rs
@@ -101,6 +101,8 @@ struct ActionPackRaw {
     input: PathBuf,
     #[arg(index = 2)]
     utoc: PathBuf,
+    #[arg(long)]
+    compression: Option<retoc::compression::CompressionMethod>,
 }
 
 #[derive(Parser, Debug)]
@@ -181,6 +183,8 @@ struct ActionToZen {
     /// Do not run in parallel. Useful for debugging
     #[arg(long)]
     no_parallel: bool,
+    #[arg(long)]
+    compression: Option<retoc::compression::CompressionMethod>,
 }
 
 #[derive(Parser, Debug)]
@@ -609,7 +613,7 @@ fn action_unpack_raw(args: ActionUnpackRaw, config: Arc<Config>) -> Result<()> {
 fn action_pack_raw(args: ActionPackRaw, _config: Arc<Config>) -> Result<()> {
     let manifest: raw::RawIoManifest = serde_json::from_reader(BufReader::new(fs::File::open(args.input.join("manifest.json"))?))?;
 
-    let mut writer = IoStoreWriter::new(args.utoc, manifest.version, None, manifest.mount_point.into())?;
+    let mut writer = IoStoreWriter::new(args.utoc, manifest.version, None, manifest.mount_point.into(),args.compression)?;
     for entry in args.input.join("chunks").read_dir()? {
         let entry = entry?;
         let chunk_id = FIoChunkIdRaw::from_str(entry.file_name().to_string_lossy().as_ref())?;
@@ -774,7 +778,7 @@ fn action_to_zen(args: ActionToZen, config: Arc<Config>) -> Result<()> {
 
     let toc_version = config.toc_version_override.unwrap_or(args.version.toc_version());
 
-    let mut writer = IoStoreWriter::new(&args.output, toc_version, Some(container_header_version), mount_point.into())?;
+    let mut writer = IoStoreWriter::new(&args.output, toc_version, Some(container_header_version), mount_point.into(),args.compression)?;
 
     let log = Log::new_stdout(args.verbose, args.debug);
     let mut asset_paths = vec![];
@@ -1053,7 +1057,8 @@ fn action_gen_script_objects(args: ActionGenScriptObjects, _config: Arc<Config>)
         }
     }
 
-    let mut writer = IoStoreWriter::new(&args.output, args.version.toc_version(), None, UEPathBuf::new())?;
+    //TODO add compression flags
+    let mut writer = IoStoreWriter::new(&args.output, args.version.toc_version(), None, UEPathBuf::new(),None)?;
 
     let use_new_format = args.version.toc_version() > EIoStoreTocVersion::PerfectHash;
 


### PR DESCRIPTION
- Add optional `CompressionMethod` to `IoStoreWriter::new`
- Split `write_chunk` into `write_chunk_inner` + `write_chunk_uncompressed`
- Expose `--compression` flag on `pack-raw` and `to-zen` CLI subcommands